### PR TITLE
feat: respect old machine ssh host keys

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -309,6 +309,7 @@ infect() {
   echo etc/nixos                  >> /etc/NIXOS_LUSTRATE
   echo etc/resolv.conf            >> /etc/NIXOS_LUSTRATE
   echo root/.nix-defexpr/channels >> /etc/NIXOS_LUSTRATE
+  (cd / && ls etc/ssh/ssh_host_*_key* || true) >> /etc/NIXOS_LUSTRATE
 
   rm -rf /boot.bak
   isEFI && umount "$esp"


### PR DESCRIPTION
When lustrating another machine, you usually are already connected by SSH. Thus, you usually already trusted that machine's keys.

With this patch, those keys are kept, so after booting into nixos, you still connect to the same trusted IP+Keys combination.

@moduon MT-904